### PR TITLE
feat: sticky top bar when scrolling down menus

### DIFF
--- a/app/location/[location].tsx
+++ b/app/location/[location].tsx
@@ -20,9 +20,10 @@ import { filterFoodItems } from '~/utils/filter';
 import { cn } from '~/utils/utils';
 import CategoryHeader from './components/CategoryHeader';
 import FoodItemRow from './components/FoodItemRow';
-import LocationHeader from './components/LocationHeader';
+import { LocationHeaderBody } from './components/LocationHeader';
 import ScrollToTopButton from './components/ScrollToTopButton';
 import SkeletonItem from './components/SkeletonItem';
+import TopBar from '~/components/TopBar';
 
 /**
  * Filter items based on search query and user-selected filters
@@ -295,7 +296,14 @@ const Location = () => {
   return (
     <View style={{ flex: 1, backgroundColor: isDarkMode ? '#171717' : '#fff' }}>
       <Stack.Screen options={{ title: 'Location' }} />
+
+      {/* Sticky TopBar positioned above the list - outside Container to avoid padding */}
+      <View className={cn('flex px-6 py-6 z-10 justify-center items-center', isDarkMode ? 'bg-neutral-900' : 'bg-white')}>
+        <TopBar variant="location" />
+      </View>
+
       <Container className="relative mx-0 w-full flex-1">
+
         <FlashList
           estimatedItemSize={60}
           extraData={favorites}
@@ -306,7 +314,7 @@ const Location = () => {
           data={displayedItems}
           removeClippedSubviews
           scrollEnabled={!isSwitchingMenus}
-          ListHeaderComponent=<LocationHeader
+          ListHeaderComponent=<LocationHeaderBody
             location={location}
             selectedMenu={selectedMenu ?? null}
             setSelectedMenu={setSelectedMenu}

--- a/app/location/components/LocationHeader.tsx
+++ b/app/location/components/LocationHeader.tsx
@@ -26,7 +26,7 @@ interface LocationHeaderProps {
   onDateChange: (date: string) => void;
 }
 
-const LocationHeader = React.memo(
+export const LocationHeaderBody = React.memo(
   ({
     location,
     selectedMenu,
@@ -82,8 +82,6 @@ const LocationHeader = React.memo(
         {/* Content that's hidden when search is focused */}
         {!isSearchFocused && (
           <>
-            <TopBar variant="location" />
-
             <View className="gap-y-4">
               {/* Temporarily Closed Banner */}
               {locationData?.force_close && (
@@ -190,6 +188,36 @@ const LocationHeader = React.memo(
             </View>
           </View>
         )}
+      </View>
+    );
+  },
+);
+
+const LocationHeader = React.memo(
+  ({
+    location,
+    selectedMenu,
+    setSelectedMenu,
+    filters,
+    query,
+    setQuery,
+    selectedDate,
+    onDateChange,
+  }: LocationHeaderProps) => {
+    // Backward-compatible wrapper
+    return (
+      <View>
+        <TopBar variant="location" />
+        <LocationHeaderBody
+          location={location}
+          selectedMenu={selectedMenu}
+          setSelectedMenu={setSelectedMenu}
+          filters={filters}
+          query={query}
+          setQuery={setQuery}
+          selectedDate={selectedDate}
+          onDateChange={onDateChange}
+        />
       </View>
     );
   },

--- a/app/location/components/LocationHeader.tsx
+++ b/app/location/components/LocationHeader.tsx
@@ -78,7 +78,7 @@ export const LocationHeaderBody = React.memo(
     }, [location, locationData, db.select]);
 
     return (
-      <View className="mx-6 mt-6 flex gap-y-5">
+      <View className="mx-6 flex gap-y-5">
         {/* Content that's hidden when search is focused */}
         {!isSearchFocused && (
           <>

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -13,6 +13,7 @@ import { useMealPlanStore } from '~/store/useMealPlanStore';
 import { useSettingsStore } from '~/store/useSettingsStore';
 import { COLORS } from '~/utils/colors';
 import Alert from './Alert';
+import { red } from 'react-native-reanimated/lib/typescript/Colors';
 
 const icon = require('../assets/image.png');
 

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -13,7 +13,6 @@ import { useMealPlanStore } from '~/store/useMealPlanStore';
 import { useSettingsStore } from '~/store/useSettingsStore';
 import { COLORS } from '~/utils/colors';
 import Alert from './Alert';
-import { red } from 'react-native-reanimated/lib/typescript/Colors';
 
 const icon = require('../assets/image.png');
 


### PR DESCRIPTION
Makes top bar sticky when scrolling so that going back to the top of the page is not necessary to exit the menu. This works on Android in the emulator, but I can't test this for iOS though.

Before:

https://github.com/user-attachments/assets/58f9c07d-d8ef-4cde-b24d-c2f24202cc51

After:

https://github.com/user-attachments/assets/ee44d4a7-10e0-4558-a4af-31382acca12d

